### PR TITLE
Correction to timer interrupt rate

### DIFF
--- a/machine/sbi_entry.S
+++ b/machine/sbi_entry.S
@@ -56,7 +56,7 @@ sbi_base:
 
   # timebase
   .align 4
-  li a0, 10000000 # or, you know, we could provide the correct answer
+  li a0, 250000 # or, you know, we could provide the correct answer
   ret
 
   # shutdown


### PR DESCRIPTION
This value is just a guess originally, and is far too slow/high for the clock rate we are using.